### PR TITLE
Support for require('paroller.js')

### DIFF
--- a/dist/jquery.paroller.js
+++ b/dist/jquery.paroller.js
@@ -38,7 +38,7 @@
 		}
 	};
 
- 	$.fn.paroller = function () {
+ 	$.fn.paroller = function (options) {
 		var windowHeight = $(window).height();
 		var documentHeight = $(document).height();
 

--- a/dist/jquery.paroller.js
+++ b/dist/jquery.paroller.js
@@ -3,108 +3,117 @@
  * https://github.com/tgomilar/paroller.js
  * preview: https://tgomilar.github.io/paroller/
  **/
+ (function (factory) {
+ 	'use strict';
 
-(function ($) {
-    'use strict';
+ 	if (typeof module === 'object' && typeof module.exports === 'object') {
+ 		module.exports = factory(require('jquery'));
+ 	}
+ 	else {
+ 		factory(jQuery);
+ 	}
+ })(function ($) {
+ 	'use strict';
 
-    var elem = $('[data-paroller-factor]');
-    var setDirection = {
-        bgVertical: function (elem, bgOffset) {
-            return elem.css({'background-position': 'center ' + -bgOffset + 'px'});
-        },
-        bgHorizontal: function (elem, bgOffset) {
-            return elem.css({'background-position': -bgOffset + 'px' + ' center'});
-        },
-        vertical: function (elem, elemOffset) {
-            return elem.css({
-                '-webkit-transform': 'translateY(' + elemOffset + 'px)',
-                '-moz-transform': 'translateY(' + elemOffset + 'px)',
-                'transform': 'translateY(' + elemOffset + 'px)'
-            });
-        },
-        horizontal: function (elem, elemOffset) {
-            return elem.css({
-                '-webkit-transform': 'translateX(' + elemOffset + 'px)',
-                '-moz-transform': 'translateX(' + elemOffset + 'px)',
-                'transform': 'translateX(' + elemOffset + 'px)'
-            });
-        }
-    };
+	var setDirection = {
+		bgVertical: function (elem, bgOffset) {
+			return elem.css({'background-position': 'center ' + -bgOffset + 'px'});
+		},
+		bgHorizontal: function (elem, bgOffset) {
+			return elem.css({'background-position': -bgOffset + 'px' + ' center'});
+		},
+		vertical: function (elem, elemOffset) {
+			return elem.css({
+				'-webkit-transform': 'translateY(' + elemOffset + 'px)',
+				'-moz-transform': 'translateY(' + elemOffset + 'px)',
+				'transform': 'translateY(' + elemOffset + 'px)'
+			});
+		},
+		horizontal: function (elem, elemOffset) {
+			return elem.css({
+				'-webkit-transform': 'translateX(' + elemOffset + 'px)',
+				'-moz-transform': 'translateX(' + elemOffset + 'px)',
+				'transform': 'translateX(' + elemOffset + 'px)'
+			});
+		}
+	};
 
-    $.fn.paroller = function (options) {
-        var windowHeight = $(window).height();
-        var documentHeight = $(document).height();
+ 	$.fn.paroller = function () {
+		var windowHeight = $(window).height();
+		var documentHeight = $(document).height();
 
-        // default options
-        var options = $.extend({
-            factor: 0, // - to +
-            type: 'background', // foreground
-            direction: 'vertical' // horizontal
-        }, options);
+		// default options
+		var options = $.extend({
+			factor: 0, // - to +
+			type: 'background', // foreground
+			direction: 'vertical' // horizontal
+		}, options);
 
-        elem.each(function () {
-            var working = false;
-            var $this = $(this);
-            var offset = $this.offset().top;
-            var height = $this.outerHeight();
-            var dataFactor = $this.data('paroller-factor');
-            var dataType = $this.data('paroller-type');
-            var dataDirection = $this.data('paroller-direction');
+		return this.each(function () {
+			var working = false;
+			var $this = $(this);
+			var offset = $this.offset().top;
+			var height = $this.outerHeight();
+			var dataFactor = $this.data('paroller-factor');
+			var dataType = $this.data('paroller-type');
+			var dataDirection = $this.data('paroller-direction');
 
-            var factor = (dataFactor) ? dataFactor : options.factor;
-            var type = (dataType) ? dataType : options.type;
-            var direction = (dataDirection) ? dataDirection : options.direction;
-            var bgOffset = Math.round(offset * factor);
-            var transform = Math.round((offset - (windowHeight / 2) + height) * factor);
+			var factor = (dataFactor) ? dataFactor : options.factor;
+			var type = (dataType) ? dataType : options.type;
+			var direction = (dataDirection) ? dataDirection : options.direction;
+			var bgOffset = Math.round(offset * factor);
+			var transform = Math.round((offset - (windowHeight / 2) + height) * factor);
 
-            if (type == 'background') {
-                if (direction == 'vertical') {
-                    setDirection.bgVertical($this, bgOffset);
-                }
-                else if (direction == 'horizontal') {
-                    setDirection.bgHorizontal($this, bgOffset);
-                }
-            }
-            else if (type == 'foreground') {
-                if (direction == 'vertical') {
-                    setDirection.vertical($this, transform);
-                }
-                else if (direction == 'horizontal') {
-                    setDirection.horizontal($this, transform);
-                }
-            }
+			if (type == 'background') {
+				if (direction == 'vertical') {
+					setDirection.bgVertical($this, bgOffset);
+				}
+				else if (direction == 'horizontal') {
+					setDirection.bgHorizontal($this, bgOffset);
+				}
+			}
+			else if (type == 'foreground') {
+				if (direction == 'vertical') {
+					setDirection.vertical($this, transform);
+				}
+				else if (direction == 'horizontal') {
+					setDirection.horizontal($this, transform);
+				}
+			}
 
-            var scrollAction = function () {
-                working = false;
-            };
+			var scrollAction = function () {
+				working = false;
+			};
 
-            $(window).on('scroll', function () {
-                if (!working) {
-                    var scrolling = $(this).scrollTop();
-                    bgOffset = Math.round((offset - scrolling) * factor);
-                    transform = Math.round(((offset - (windowHeight / 2) + height) - scrolling) * factor);
+			$(window).on('scroll', function () {
+				if (!working) {
+					var scrolling = $(this).scrollTop();
 
-                    if (type == 'background') {
-                        if (direction == 'vertical') {
-                            setDirection.bgVertical($this, bgOffset);
-                        }
-                        else if (direction == 'horizontal') {
-                            setDirection.bgHorizontal($this, bgOffset);
-                        }
-                    }
-                    else if ((type == 'foreground') && (scrolling < documentHeight)) {
-                        if (direction == 'vertical') {
-                            setDirection.vertical($this, transform);
-                        }
-                        else if (direction == 'horizontal') {
-                            setDirection.horizontal($this, transform);
-                        }
-                    }
+					bgOffset = Math.round((offset - scrolling) * factor);
+					transform = Math.round(((offset - (windowHeight / 2) + height) - scrolling) * factor);
 
-                    window.requestAnimationFrame(scrollAction);
-                    working = true;
-                }
-            }).trigger('scroll');
-        });
-    };
-})(jQuery);
+					if (type == 'background') {
+						if (direction == 'vertical') {
+							setDirection.bgVertical($this, bgOffset);
+						}
+						else if (direction == 'horizontal') {
+							setDirection.bgHorizontal($this, bgOffset);
+						}
+					}
+					else if ((type == 'foreground') && (scrolling < documentHeight)) {
+						if (direction == 'vertical') {
+							setDirection.vertical($this, transform);
+						}
+						else if (direction == 'horizontal') {
+							setDirection.horizontal($this, transform);
+						}
+					}
+
+					window.requestAnimationFrame(scrollAction);
+
+					working = true;
+				}
+			}).trigger('scroll');
+		});
+	};
+});


### PR DESCRIPTION
I've added support for `require('paroller.js')` so that it's usable with NPM and browserify.

I've also added support for running `paroller()` on any element - not just `[data-paroller-factor]` elements.

Instead of `$('body').paroller();` you now use it like `$('div.paroller').paroller();`.